### PR TITLE
Second Screen recording

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -11,3 +11,5 @@ bot:
 plugins:
   wolfram:
     api: api-key
+  pastebin:
+    api: api-key

--- a/dctvbot.rb
+++ b/dctvbot.rb
@@ -82,6 +82,7 @@ bot = Cinch::Bot.new do
       Cinch::Plugins::Identify => { type: :nickserv, password: config['bot']['password'] },
       Plugins::Wikipedia => { max_length: 300 },
       Plugins::Wolfram => { wolfram_api_key: config['plugins']['wolfram']['api'] },
+      Plugins::DCTV::SecondScreenRec => { pastebin_api_key: config['plugins']['pastebin']['api'] }
     }
   end
 

--- a/dctvbot.rb
+++ b/dctvbot.rb
@@ -24,6 +24,7 @@ require_relative 'plugins/wikipedia'
 require_relative 'plugins/wolfram'
 require_relative 'plugins/dctv/notifier'
 require_relative 'plugins/dctv/secondscreen'
+require_relative 'plugins/dctv/secondscreenrec'
 require_relative 'plugins/dctv/status'
 require_relative 'plugins/dctv/toys/flip'
 require_relative 'plugins/dctv/toys/keywords'
@@ -69,6 +70,7 @@ bot = Cinch::Bot.new do
       Plugins::Wolfram,
       Plugins::DCTV::Notifier,
       Plugins::DCTV::SecondScreen,
+      Plugins::DCTV::SecondScreenRec,
       Plugins::DCTV::Status,
       Plugins::DCTV::Toys::Flip,
       Plugins::DCTV::Toys::Keywords,

--- a/dctvbot.rb
+++ b/dctvbot.rb
@@ -99,7 +99,7 @@ end
 class << bot
   attr_accessor :announced, :official_live, :toys_enabled, :cleverbot_enabled,
                 :search_enabled, :dctv_commands_enabled, :all_commands_enabled,
-                :record_second_screen
+                :record_second_screen, :recorded_second_screen_list
 end
 bot.announced = Array.new
 bot.official_live = false
@@ -110,6 +110,7 @@ bot.dctv_commands_enabled = true
 bot.all_commands_enabled = true
 
 bot.record_second_screen = false
+bot.recorded_second_screen_list = Array.new
 
 results = dctvApiJson
 results.each do |result|

--- a/dctvbot.rb
+++ b/dctvbot.rb
@@ -98,7 +98,8 @@ end
 
 class << bot
   attr_accessor :announced, :official_live, :toys_enabled, :cleverbot_enabled,
-                :search_enabled, :dctv_commands_enabled, :all_commands_enabled
+                :search_enabled, :dctv_commands_enabled, :all_commands_enabled,
+                :record_second_screen
 end
 bot.announced = Array.new
 bot.official_live = false
@@ -107,6 +108,8 @@ bot.cleverbot_enabled = true
 bot.search_enabled = true
 bot.dctv_commands_enabled = true
 bot.all_commands_enabled = true
+
+bot.record_second_screen = false
 
 results = dctvApiJson
 results.each do |result|

--- a/dctvbot.rb
+++ b/dctvbot.rb
@@ -79,7 +79,7 @@ bot = Cinch::Bot.new do
     c.plugins.options = {
       Cinch::Plugins::Identify => { type: :nickserv, password: config['bot']['password'] },
       Plugins::Wikipedia => { max_length: 300 },
-      Plugins::Wolfram => { api_id: config['plugins']['wolfram']['api'] }
+      Plugins::Wolfram => { wolfram_api_key: config['plugins']['wolfram']['api'] },
     }
   end
 

--- a/plugins/dctv/secondscreen.rb
+++ b/plugins/dctv/secondscreen.rb
@@ -12,6 +12,13 @@ module Plugins
       match /secs (.+)/
 
       def execute(m, url)
+        if url == "off" && @bot.record_second_screen
+          # Disable second screen recording
+          @bot.record_second_screen = false
+          @bot.recorded_second_screen_list.clear
+          return
+        end
+
         if @bot.record_second_screen
           @bot.recorded_second_screen_list.push(url)
         end

--- a/plugins/dctv/secondscreen.rb
+++ b/plugins/dctv/secondscreen.rb
@@ -12,6 +12,10 @@ module Plugins
       match /secs (.+)/
 
       def execute(m, url)
+        if @bot.record_second_screen
+          @bot.recorded_second_screen_list.push(url)
+        end
+
         response = HTTParty.get("http://diamondclub.tv/api/secondscreen.php?url=#{url}&pro=4938827&user=#{m.user.nick}")
         m.user.notice "Command Sent. Response: #{response}"
       end

--- a/plugins/dctv/secondscreen.rb
+++ b/plugins/dctv/secondscreen.rb
@@ -19,7 +19,14 @@ module Plugins
           return
         end
 
+        if url == "clear" && @bot.record_second_screen
+          # Clear second screen recording
+          @bot.recorded_second_screen_list.clear
+          return
+        end
+
         if @bot.record_second_screen
+          # Push new link onto second screen recording
           @bot.recorded_second_screen_list.push(url)
         end
 

--- a/plugins/dctv/secondscreenrec.rb
+++ b/plugins/dctv/secondscreenrec.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+
+module Plugins
+  module DCTV
+
+    class SecondScreenRec
+      include Cinch::Plugin
+      include Cinch::Extensions::Authentication
+
+      enable_authentication
+
+      match /secsrec on/, method: :on
+      def on(m)
+        m.user.notice "Second Screen Recording enabled"
+      end
+
+      match /secsrec off/, method: :off
+      def off(m)
+        m.user.notice "Second Screen Recording disabled"
+      end
+    end
+
+  end
+end

--- a/plugins/dctv/secondscreenrec.rb
+++ b/plugins/dctv/secondscreenrec.rb
@@ -12,6 +12,7 @@ module Plugins
       match /secsrec on/, method: :on
       def on(m)
         @bot.record_second_screen = true
+        @bot.recorded_second_screen_list.clear
 
         m.user.notice "Second Screen Recording enabled"
       end
@@ -19,6 +20,7 @@ module Plugins
       match /secsrec off/, method: :off
       def off(m)
         @bot.record_second_screen = false
+        @bot.recorded_second_screen_list.clear
 
         m.user.notice "Second Screen Recording disabled"
       end

--- a/plugins/dctv/secondscreenrec.rb
+++ b/plugins/dctv/secondscreenrec.rb
@@ -47,6 +47,8 @@ module Plugins
         res = Net::HTTP.post_form(url, params)
 
         m.reply res.body
+
+        list.clear
       end
     end
 

--- a/plugins/dctv/secondscreenrec.rb
+++ b/plugins/dctv/secondscreenrec.rb
@@ -11,11 +11,15 @@ module Plugins
 
       match /secsrec on/, method: :on
       def on(m)
+        @bot.record_second_screen = true
+
         m.user.notice "Second Screen Recording enabled"
       end
 
       match /secsrec off/, method: :off
       def off(m)
+        @bot.record_second_screen = false
+
         m.user.notice "Second Screen Recording disabled"
       end
     end

--- a/plugins/dctv/secondscreenrec.rb
+++ b/plugins/dctv/secondscreenrec.rb
@@ -29,6 +29,8 @@ module Plugins
       def publish(m)
         list = @bot.recorded_second_screen_list
 
+        return if (list.empty?)
+
         url = URI.parse("http://pastebin.com/api/api_post.php")
 
         str = ""

--- a/plugins/dctv/secondscreenrec.rb
+++ b/plugins/dctv/secondscreenrec.rb
@@ -24,6 +24,28 @@ module Plugins
 
         m.user.notice "Second Screen Recording disabled"
       end
+
+      match /secsrec publish/, method: :publish
+      def publish(m)
+        list = @bot.recorded_second_screen_list
+
+        url = URI.parse("http://pastebin.com/api/api_post.php")
+
+        str = ""
+        list.each do |link|
+          str += "#{link}\n"
+        end
+
+        params = {
+          "api_dev_key" => config[:pastebin_api_key],
+          "api_option" => "paste", # Specifies creation
+          "api_paste_code" => str
+        }
+
+        res = Net::HTTP.post_form(url, params)
+
+        m.reply res.body
+      end
     end
 
   end

--- a/plugins/wolfram.rb
+++ b/plugins/wolfram.rb
@@ -17,7 +17,7 @@ module Plugins
     end
 
     def search(query)
-      wolfram = WolframAlpha::Client.new(config[:api_id], options = { :timeout => 30 })
+      wolfram = WolframAlpha::Client.new(config[:wolfram_api_key], options = { :timeout => 30 })
       response = wolfram.query query
       input = response["Input"] # Get the input interpretation pod.
       # result = response.find { |pod| pod.title == "Result" }

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,8 @@ A simple IRC bot for chatrealm, built using [Cinch](https://github.com/cinchrb/c
 `!schedule [v]` - Display scheduled shows for the next 48 hours via user notice. Voiced and higher users can specify the v flag to have it show in main chat.  
 
 _Restricted to users with voice or higher._  
-`!secs [on|off|clear|<url>]` - Executes Second Screen command or sets to <url>  
+`!secs [on|off|clear|<url>]` - Executes Second Screen command or sets to <url>
+`!secsrec [on|off|publish]` - Enables/disables Second Screen recording or publishes to recorded links to Pastebin
 
 **Search commands**  
 `!google <term>` - Returns the top hit on google for <term>.  


### PR DESCRIPTION
So I made another thing. No idea if it'll be useful or even if the code is half good.

It adds a new command to turn on second screen recording, which adds every second screen link to a array. When the `publish` command is called it bundles the links up and posts to pastebin (requires an API key, but it's dead simple to get hold of one).

I've tested it a bit on a local IRC install (I obviously don't have the perms on live chatrealm), but I think I've got most of the bugs. The only outstanding one that I've not come up with a solution for is the pastebin rate limits. You only get about 20 new pastes per day per api key (I haven't worked out exactly what the limit is). But I figured that ~20 is probably enough for now and if it does go over then it'll just print a "paste creation failed due to rate limits" message or something to that effect.

Feel free to make suggestions/shoot me down if you think it's a bad idea
<>